### PR TITLE
FIX: Reward users not syncing properly

### DIFF
--- a/lib/pledges.rb
+++ b/lib/pledges.rb
@@ -52,8 +52,11 @@ module ::Patreon
         new_pledges, new_reward_users, new_users = extract(pledge_data)
 
         pledges.merge!(new_pledges)
-        reward_users.merge!(new_reward_users)
         users.merge!(new_users)
+
+        Patreon::Reward.all.keys.each do |key|
+          reward_users[key] = (reward_users[key] || []) + (new_reward_users[key] || [])
+        end
       end
 
       reward_users['0'] = pledges.keys

--- a/plugin.rb
+++ b/plugin.rb
@@ -38,6 +38,14 @@ after_initialize do
       store.set(key, value)
     end
 
+    class Reward
+
+      def self.all
+        Patreon.get("rewards") || {}
+      end
+
+    end
+
     class RewardUser
 
       def self.all

--- a/spec/fixtures/campaigns.json
+++ b/spec/fixtures/campaigns.json
@@ -49,6 +49,18 @@
           {
             "id": "0",
             "type": "reward"
+          },
+          {
+            "id": "999997",
+            "type": "reward"
+          },
+          {
+            "id": "999998",
+            "type": "reward"
+          },
+          {
+            "id": "999999",
+            "type": "reward"
           }
         ]
       },
@@ -150,6 +162,87 @@
         "user_limit": null
       },
       "id": "0",
+      "relationships": {
+        "creator": {
+          "data": {
+            "id": "1111111",
+            "type": "user"
+          },
+          "links": {
+            "related": "https://www.patreon.com/api/user/1111111"
+          }
+        }
+      },
+      "type": "reward"
+    },
+    {
+      "attributes": {
+        "amount": 10,
+        "amount_cents": 10,
+        "created_at": null,
+        "description": "Standard",
+        "id": "0",
+        "remaining": 0,
+        "requires_shipping": false,
+        "type": "reward",
+        "url": null,
+        "user_limit": null
+      },
+      "id": "999997",
+      "relationships": {
+        "creator": {
+          "data": {
+            "id": "1111111",
+            "type": "user"
+          },
+          "links": {
+            "related": "https://www.patreon.com/api/user/1111111"
+          }
+        }
+      },
+      "type": "reward"
+    },
+    {
+      "attributes": {
+        "amount": 100,
+        "amount_cents": 100,
+        "created_at": null,
+        "description": "Pro",
+        "id": "0",
+        "remaining": 0,
+        "requires_shipping": false,
+        "type": "reward",
+        "url": null,
+        "user_limit": null
+      },
+      "id": "999998",
+      "relationships": {
+        "creator": {
+          "data": {
+            "id": "1111111",
+            "type": "user"
+          },
+          "links": {
+            "related": "https://www.patreon.com/api/user/1111111"
+          }
+        }
+      },
+      "type": "reward"
+    },
+    {
+      "attributes": {
+        "amount": 1000,
+        "amount_cents": 1000,
+        "created_at": null,
+        "description": "Premium",
+        "id": "0",
+        "remaining": 0,
+        "requires_shipping": false,
+        "type": "reward",
+        "url": null,
+        "user_limit": null
+      },
+      "id": "999999",
       "relationships": {
         "creator": {
           "data": {

--- a/spec/fixtures/pledge.json
+++ b/spec/fixtures/pledge.json
@@ -35,7 +35,7 @@
       },
       "reward": {
         "data": {
-          "id": "599336",
+          "id": "999999",
           "type": "reward"
         },
         "links": {
@@ -82,14 +82,14 @@
         "amount_cents": 1,
         "created_at": null,
         "description": "Patrons Only",
-        "id": "0",
+        "id": "999999",
         "remaining": 0,
         "requires_shipping": false,
         "type": "reward",
         "url": null,
         "user_limit": null
       },
-      "id": "0",
+      "id": "999999",
       "relationships": {
         "creator": {
           "data": {

--- a/spec/pledges_spec.rb
+++ b/spec/pledges_spec.rb
@@ -37,16 +37,16 @@ RSpec.describe ::Patreon::Campaign do
       .and change { Badge.count }.by(1)
 
     expect(get('pledges').count).to eq(2)
-    expect(get('rewards').count).to eq(2)
+    expect(get('rewards').count).to eq(5)
     expect(get('users').count).to eq(3)
-    expect(get('reward-users').count).to eq(3)
+    expect(get('reward-users')["0"].count).to eq(2)
     expect(get('filters').count).to eq(1)
 
     freeze_time("2017-11-11T20:59:52+00:00")
     expect {
       described_class.update!
     }.to change { get('pledges').count }.by(1)
-      .and change { get('reward-users').count }.by(1)
+      .and change { get('reward-users')["0"].count }.by(1)
 
     expect { # To check `add_model_callback(User, :after_commit, on: :create)` in plugin.rb
       get('users').each do |id, user|

--- a/spec/requests/patreon_webhook_controller_spec.rb
+++ b/spec/requests/patreon_webhook_controller_spec.rb
@@ -31,6 +31,19 @@ RSpec.describe ::Patreon::PatreonWebhookController do
       let(:digest) { OpenSSL::Digest::MD5.new }
       let(:secret) { SiteSetting.patreon_webhook_secret = "WEBHOOK SECRET" }
 
+      before do
+        Patreon.set("rewards", {
+          "0": {
+            "title": "All Patrons",
+            "amount_cents": 0
+          },
+          "999999": {
+            "title": "Premium",
+            "amount_cents": 1000
+          }
+        })
+      end
+
       def add_pledge
         pledge_data = JSON.parse(body)
         Patreon::Pledges.create!(pledge_data.dup)


### PR DESCRIPTION
In API response if more than one pages of pledges are available then reward users not syncing properly.