### PR TITLE
Add validation to patreon_login_enabled setting

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -15,6 +15,8 @@ en:
     patreon_donation_prompt_enabled: "Enable donation prompt?"
     patreon_donation_prompt_show_after_topics: "Show donation prompt after n topics"
     patreon_donation_prompt_campaign_url: "Donation prompt campaign URL"
+    errors:
+      patreon_creator_username_not_set: "You need to set the Patreon Creator Discourse Username setting before enabling Patreon Login."
   dashboard:
     patreon:
       access_token_invalid: "Patreon Creator's access and refresh token values are incorrect. You must copy-paste new tokens from <a href='https://www.patreon.com/platform/documentation/clients'>Patreon website</a> to <a href='%{base_path}/admin/site_settings/category/all_results?filter=patreon'>site settings</a>."

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -5,6 +5,7 @@ plugins:
   patreon_login_enabled:
     default: false
     client: true
+    validator: 'PatreonLoginEnabledValidator'
   patreon_client_id:
     default: ''
   patreon_client_secret:

--- a/lib/validators/patreon_login_enabled_validator.rb
+++ b/lib/validators/patreon_login_enabled_validator.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class PatreonLoginEnabledValidator
+  def initialize(opts = {})
+    @opts = opts
+  end
+
+  def valid_value?(val)
+    return true if val == 'f'
+    return false if SiteSetting.patreon_creator_discourse_username.blank?
+    true
+  end
+
+  def error_message
+    I18n.t('site_settings.errors.patreon_creator_username_not_set')
+  end
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -17,6 +17,9 @@ register_asset 'stylesheets/patreon.scss'
 
 register_svg_icon "fab-patreon" if respond_to?(:register_svg_icon)
 
+# Site setting validators must be loaded before initialize
+require_relative 'lib/validators/patreon_login_enabled_validator'
+
 after_initialize do
 
   require_dependency 'admin_constraint'


### PR DESCRIPTION
We get quite a few support requests from sites that have enabled Patreon login without having filled in the `patreon creator discourse username` setting. This PR adds a validator to check that the Discourse username has been entered before allowing Patreon login to be enabled.