### PR TITLE
FIX: Never add query params to the callback URL

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -154,6 +154,10 @@ after_initialize do
         response.parsed
       end
     end
+
+    def callback_url
+      full_host + script_name + callback_path
+    end
   end
 
   DiscourseEvent.on(:user_created) do |user|


### PR DESCRIPTION
We never want query params to be added to the callback URL. This same override is used in a number of OAuth2 omniauth providers, including GitHub and Google.

(Similar implementations [here](https://github.com/wingrunr21/omniauth-amazon/blob/master/lib/omniauth/strategies/amazon.rb#L61-L63) and [here](https://github.com/zquestz/omniauth-google-oauth2/blob/v0.8.2/lib/omniauth/strategies/google_oauth2.rb#L104-L106))