### PR TITLE
SECURITY: Check for email verification status during login

### DIFF
--- a/db/post_migrate/20221025153038_deactivate_unverified_email_patreon_accounts.rb
+++ b/db/post_migrate/20221025153038_deactivate_unverified_email_patreon_accounts.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class DeactivateUnverifiedEmailPatreonAccounts < ActiveRecord::Migration[6.1]
+  def up
+    execute <<~SQL
+      UPDATE users SET active = false
+      WHERE users.id IN (
+        SELECT user_id FROM user_associated_accounts
+        WHERE provider_name = 'patreon'
+        AND extra -> 'raw_info' -> 'data' -> 'attributes' ->> 'is_email_verified' = 'false'
+      )
+    SQL
+  end
+
+  def down
+    # noop
+  end
+end

--- a/db/post_migrate/20221026043851_delete_unverified_patreon_user_info.rb
+++ b/db/post_migrate/20221026043851_delete_unverified_patreon_user_info.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+class DeleteUnverifiedPatreonUserInfo < ActiveRecord::Migration[6.1]
+  def up
+    execute <<~SQL
+      DELETE FROM user_auth_tokens
+      WHERE user_id IN (
+        SELECT user_id
+        FROM user_associated_accounts
+        WHERE provider_name = 'patreon'
+        AND COALESCE(JSON_EXTRACT_PATH(extra::json, 'raw_info', 'data', 'attributes', 'is_email_verified')::text, 'false') <> 'true'
+      )
+    SQL
+
+    execute <<~SQL
+      UPDATE user_api_keys
+      SET revoked_at = NOW()
+      WHERE user_id IN (
+        SELECT user_id
+        FROM user_associated_accounts
+        WHERE provider_name = 'patreon'
+        AND COALESCE(JSON_EXTRACT_PATH(extra::json, 'raw_info', 'data', 'attributes', 'is_email_verified')::text, 'false') <> 'true'
+      )
+    SQL
+
+    execute <<~SQL
+      UPDATE api_keys
+      SET revoked_at = NOW()
+      WHERE created_by_id IN (
+        SELECT user_id
+        FROM user_associated_accounts
+        WHERE provider_name = 'patreon'
+        AND COALESCE(JSON_EXTRACT_PATH(extra::json, 'raw_info', 'data', 'attributes', 'is_email_verified')::text, 'false') <> 'true'
+      )
+    SQL
+
+    execute <<~SQL
+      DELETE FROM user_associated_accounts
+      WHERE provider_name = 'patreon'
+      AND COALESCE(JSON_EXTRACT_PATH(extra::json, 'raw_info', 'data', 'attributes', 'is_email_verified')::text, 'false') <> 'true'
+    SQL
+  end
+
+  def down
+    # noop
+  end
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -178,6 +178,7 @@ class ::OmniAuth::Strategies::Patreon < ::OmniAuth::Strategies::OAuth2
   info do
     {
       email: raw_info['data']['attributes']['email'],
+      email_verified: raw_info['data']['attributes']['is_email_verified'],
       name: raw_info['data']['attributes']['full_name']
     }
   end
@@ -233,6 +234,10 @@ class Auth::PatreonAuthenticator < Auth::ManagedAuthenticator
 
   def enabled?
     SiteSetting.patreon_login_enabled
+  end
+
+  def primary_email_verified?(auth_token)
+    auth_token[:info][:email_verified]
   end
 end
 


### PR DESCRIPTION
This commit also includes a migration which will deactivate any users with existing connections to unverified-email Patreon accounts. They will be asked to verify their email on their next login.