### PR TITLE
DEV: Do not mutate PluginOutlet arguments

### DIFF
--- a/assets/javascripts/discourse/templates/connectors/admin-user-details/patreon.js
+++ b/assets/javascripts/discourse/templates/connectors/admin-user-details/patreon.js
@@ -2,9 +2,12 @@ import { ajax } from "discourse/lib/ajax";
 import { userPath } from "discourse/lib/url";
 
 export default {
-  shouldRender(args, component) {
-    component.args.patron_url = "https://patreon.com/members";
-    return component.siteSettings.patreon_enabled && args.model.patreon_id;
+  shouldRender(args, context) {
+    return context.siteSettings.patreon_enabled && args.model.patreon_id;
+  },
+
+  setupComponent(args, component) {
+    component.set("patron_url", "https://patreon.com/members");
   },
 
   actions: {


### PR DESCRIPTION
It looks like the intention here was to set a property on this `patreon` connector. However, calling `args.set()` was causing the arguments to be mutated for other plugin connectors using the same outlet. Setting the default value in `setupComponent` is much safer.