### PR TITLE
FIX: retrieve the creator's access token using the "token" property.

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -10,15 +10,19 @@ plugins:
     default: ''
   patreon_client_secret:
     default: ''
+    secret: true
   patreon_webhook_secret:
     default: ''
+    secret: true
   patreon_creator_discourse_username:
     default: ''
     type: username
   patreon_creator_access_token:
     default: ''
+    secret: true
   patreon_creator_refresh_token:
     default: ''
+    secret: true
   patreon_declined_pledges_grace_period_days:
     default: 7
   max_patreon_api_reqs_per_hr:

--- a/plugin.rb
+++ b/plugin.rb
@@ -230,7 +230,7 @@ class Auth::PatreonAuthenticator < Auth::ManagedAuthenticator
     user = result.user
     discourse_username = SiteSetting.patreon_creator_discourse_username
     if discourse_username.present? && user && user.username == discourse_username
-      SiteSetting.patreon_creator_access_token = auth_token.credentials["access_token"]
+      SiteSetting.patreon_creator_access_token = auth_token.credentials["token"]
       SiteSetting.patreon_creator_refresh_token = auth_token.credentials["refresh_token"]
     end
 


### PR DESCRIPTION
If we get the token value using the "access_token" property, it returns an empty value. In that case, all the API calls will fail.