### PR TITLE
DEV: Remove use of Ember jquery-integration

### DIFF
--- a/assets/javascripts/discourse/initializers/patreon.js
+++ b/assets/javascripts/discourse/initializers/patreon.js
@@ -51,7 +51,7 @@ function initWithApi(api) {
         const expires = moment().add(30, "d").toDate();
         $.cookie(cookieName, "t", { expires });
 
-        this.$().fadeOut(700);
+        $(this.element).fadeOut(700);
       },
     },
   });


### PR DESCRIPTION
This has been deprecated for some time, and Discourse will be removing the integration imminently. JQuery itself is still available, so we can replicate the old behaviour using the jquery global and a selector scoped to the component's element.