### PR TITLE
DEV: Replace deprecated queue_jobs site setting in tests

### DIFF
--- a/spec/requests/patreon_webhook_controller_spec.rb
+++ b/spec/requests/patreon_webhook_controller_spec.rb
@@ -6,7 +6,7 @@ require "json"
 require_relative "../spec_helper"
 
 RSpec.describe ::Patreon::PatreonWebhookController do
-  before { SiteSetting.queue_jobs = false }
+  before { Jobs.run_immediately! }
 
   describe "index" do
     describe "header checking" do


### PR DESCRIPTION
### What is this change?

The `#queue_jobs=` method on site settings has been [deprecated](https://github.com/discourse/discourse/commit/1b65469b64e9e569fed67ae11f1dd9ee37702f5c) and replaced by `Jobs.run_later!` and `Jobs.run_immediately!`. This PR replaces usages in this plugin so we can remove the fallback in core.

The fallback used in core for reference:

https://github.com/discourse/discourse/blob/main/app/models/site_setting.rb#L109-L115