### PR TITLE
DEV: Change settings root from plugins: to discourse_patreon

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1,4 +1,9 @@
 en:
+  admin_js:
+    admin:
+      site_settings:
+        categories:
+          discourse_patreon: "Discourse Patreon"
   js:
     login:
       patreon:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,4 +1,4 @@
-plugins:
+discourse_patreon:
   patreon_enabled:
     default: false
     client: true


### PR DESCRIPTION
This is so the plugins settings are better categorized in the site settings UI.