### PR TITLE
DEV: Update more deprecated Font Awesome icon names

### DIFF
--- a/assets/javascripts/discourse/templates/admin/plugins-patreon.hbs
+++ b/assets/javascripts/discourse/templates/admin/plugins-patreon.hbs
@@ -19,7 +19,7 @@
               <DButton
                 @action={{action "delete"}}
                 @actionParam={{rule}}
-                @icon="far-trash-alt"
+                @icon="far-trash-can"
                 @title="patreon.delete"
                 class="delete btn-danger"
               />


### PR DESCRIPTION
This PR updates more deprecated Font Awesome icon names. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.