### PR TITLE
Add event name to verbose webhook log

### DIFF
--- a/app/controllers/patreon_webhook_controller.rb
+++ b/app/controllers/patreon_webhook_controller.rb
@@ -28,7 +28,7 @@ class ::Patreon::PatreonWebhookController < ApplicationController
 
     if SiteSetting.patreon_verbose_log
       Rails.logger.warn(
-        "Patreon verbose log for Webhook:\n  Id = #{patreon_id}\n  Data = #{pledge_data.inspect}",
+        "Patreon verbose log for Webhook:\n  Event = #{event}\n Id = #{patreon_id}\n  Data = #{pledge_data.inspect}",
       )
     end
 


### PR DESCRIPTION
Currently, the event name comes in as `X-Patreon-Event` header in the request. There's no way of knowing the event name in the log which makes debugging issues very difficult.